### PR TITLE
Add easing and overshoot

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -57,11 +57,11 @@ function rotatePromise (el, draggable, rotateTo) {
   // rotateDirection = 1 => clockwise
   // rotateDirection = -1 => counterclockwise
   const rotateDirection = Math.round(random())?1:-1
-  const rotateQuantity = Math.ceil(random() * 1) // a number between 1 and 2 inclusive
+  const rotateQuantity = Math.ceil(random()) // a number between 1 and 2 inclusive
   const overshoot = 5 + Math.ceil(random() * 5) // Number of degrees to overshoot
 
   // rotation is cumulative so calculate actual ending degrees
-  let circs = Math.ceil(draggable.rotation / 360) + rotateQuantity * rotateDirection
+  let circs = Math.floor(draggable.rotation / 360) + rotateQuantity * rotateDirection
   const rotateToActual = circs * 360 + rotateTo
   const rotateToOvershoot = rotateToActual + overshoot * rotateDirection
   const duration = Math.abs(draggable.rotation - rotateToOvershoot) / 200 * 60  // 200 degrees per second on average


### PR DESCRIPTION
The final dial, which moves on its own, was a little bland.  This offers
some variation to its speed as well as a little "overshoot" motion so
that it feels more like a compass wavering around the item.

There is probably still some work to be done around nailing the easing
functions, right now it is using a cubic.  You can see a list of easing
functions over here:

https://gist.github.com/gre/1650294

as well as how they actually look over here:

https://easings.net/

The bounce isn't quite done using easing, but rather through
overshooting and wandering back recursively.

This commit also redoes the way that directionality was determined.  By
using -1 and 1 instead of 0 and 1 it becomes possible remove some
repeated code (since we were either adding or subtracting, now we can
just multiply by the direction in those cases).

This gif shows the code in action

![compass](https://user-images.githubusercontent.com/208884/47544675-43ec3080-d8b6-11e8-8db0-421f96949fe5.gif)

This would resolve #27

